### PR TITLE
remove review endpoints dependence on wally

### DIFF
--- a/app/helpers/wally_integration.py
+++ b/app/helpers/wally_integration.py
@@ -44,7 +44,6 @@ def mint_nft(current_review: Review, dive_shop: DiveShop, beach: Spot, user: Use
   }
 
   response = requests.post(request_url, headers=headers, json=payload)
-  response.raise_for_status()
   data = response.json()
   return data
 
@@ -62,7 +61,6 @@ def create_wallet(user: User):
   }
 
   response = requests.post(request_url, headers=headers, json=payload)
-  response.raise_for_status()
   data = response.json()
   return data
 
@@ -77,7 +75,6 @@ def sign_message(dive_shop: DiveShop, message: str):
     'Content-Type': 'application/json',
   }
   response = requests.post(request_url, headers=headers, json=payload)
-  response.raise_for_status()
   data = response.json()
   return data
 
@@ -89,6 +86,5 @@ def fetch_user_wallet(id):
     'Content-Type': 'application/json',
   }
   response = requests.get(request_url, headers=headers);
-  response.raise_for_status()
   data = response.json()
   return data


### PR DESCRIPTION
Considering that wally integration is no longer as crucial as it once was, I think we should remove `response.raise_for_status` so that adding a dive log still goes through even if there is a problem with the wally api.